### PR TITLE
docs(readme): typo in import

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add this to `src/hooks.client.ts`:
 
 ```typescript
 import type { HandleClientError } from '@sveltejs/kit'
-import { initializeClerkClient } from './lib/client/index.js'
+import { initializeClerkClient } from 'clerk-sveltekit';
 import { PUBLIC_CLERK_PUBLISHABLE_KEY } from '$env/static/public'
 
 initializeClerkClient(PUBLIC_CLERK_PUBLISHABLE_KEY, {


### PR DESCRIPTION
Trying out this lib. Tripped-up on a typo in the readme.

Is this fix ok?